### PR TITLE
allow user to configure mitmproxy port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,16 @@ data/excel/
 data/announce/
 assets/
 
+mods/*
+!mods/.placeholder
+
+platform-tools/
+
+# Data files
+data/excel/
+data/announce/
+assets/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,12 @@
 {
     "server": {
-        "host": "192.168.86.243",
+        "host": "127.0.0.1",
         "port": 8443,
         "enableServer": true,
         "maintenanceMsg": "Server is currently under maintenance!"
+    },
+    "mitmproxy": {
+        "port": 8080
     },
     "assets": {
         "autoUpdate": true,

--- a/fridahook.py
+++ b/fridahook.py
@@ -3,11 +3,6 @@ from base64 import b64decode
 
 import frida
 
-from server.constants import CONFIG_PATH
-from server.utils import read_json
-
-HOST = read_json(CONFIG_PATH)["server"]["host"]
-
 def on_message(message, data):
     print("[%s] => %s" % (message, data))
 
@@ -171,7 +166,7 @@ def main():
     }}
 
     function init(){{
-        var proxy_url = "{HOST}";
+        var proxy_url = "127.0.0.1";
         var proxy_port = 8080;
         var mitm_cert_location_on_device = "/data/local/tmp/mitmproxy-ca-cert.cer";
 
@@ -186,7 +181,7 @@ def main():
 
     init();
 
-""".format(HOST=HOST, timeout=timeout))
+""".format(timeout=timeout))
     script.on('message', on_message)
     script.load()
     print("[!] Ctrl+D on UNIX, Ctrl+Z on Windows/cmd.exe to detach from instrumented program.\n\n")

--- a/start_mitmproxy.bat
+++ b/start_mitmproxy.bat
@@ -1,4 +1,5 @@
 @echo off
 @title Doctorate - mitmdump
 
-mitmdump.exe -s mitmproxy-cn.py
+call env\scripts\activate.bat
+py start_mitmproxy.py

--- a/start_mitmproxy.py
+++ b/start_mitmproxy.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+mitmproxy_server = json.load(open('./config/config.json', 'r'))["mitmproxy"]
+
+mitmproxy_port = mitmproxy_server["port"]
+
+os.system(
+    f"mitmdump.exe --listen-host 127.0.0.1 --listen-port {mitmproxy_port} -s mitmproxy-cn.py"
+)

--- a/startfrida.py
+++ b/startfrida.py
@@ -4,9 +4,13 @@ import lzma
 import time
 import subprocess
 from contextlib import suppress
+import json
 
 import requests
 from ppadb.client import Client as AdbClient
+
+mitmproxy_server = json.load(open('./config/config.json', 'r'))["mitmproxy"]
+mitmproxy_port = mitmproxy_server["port"]
 
 ADB_PATH = "platform-tools\\adb.exe"
 
@@ -75,4 +79,5 @@ with suppress(RuntimeError):
 time.sleep(5) # Sleep for 5 seconds to make sure that the emulator is rooted
 
 print("\nRunning frida\nNow you can start fridahook\n")
+os.system(f'{ADB_PATH} reverse tcp:8080 tcp:{mitmproxy_port}')
 os.system(f'{ADB_PATH} shell "/data/local/tmp/frida-server" &')


### PR DESCRIPTION
The original implementation let mitmproxy use the default port 8080, which is quite popular and might already be used by the user. This commit aims to fix this by allowing user to configure it.
BTW, this commit uses `adb reverse` to allow user to use `127.0.0.1` as the private server address (public address is still usable). Users now don't have to fill in their specific IP addresses (e.g. `192.168.1.3`) anymore, making this project more portable.