### PR TITLE
fix adb root improper waiting

### DIFF
--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -89,7 +89,7 @@ while True:
 print("Check the emulator and accept if it asks for root permission.")
 with suppress(RuntimeError):
     device.root()
-time.sleep(3) # Sleep for 3 seconds to make sure that the emulator is rooted
+os.system(f'{ADB_PATH} wait-for-device')
 
 cert_exists = device.shell('test -f /data/local/tmp/mitmproxy-ca-cert.cer && echo True').strip()
 if not cert_exists:

--- a/startfrida.py
+++ b/startfrida.py
@@ -72,7 +72,7 @@ while True:
 print("Check the emulator and accept if it asks for root permission.")
 with suppress(RuntimeError):
     device.root()
-time.sleep(5) # Sleep for 5 seconds to make sure that the emulator is rooted
+os.system(f'{ADB_PATH} wait-for-device')
 
 print("\nRunning frida\nNow you can start fridahook\n")
 os.system(f'{ADB_PATH} shell "/data/local/tmp/frida-server" &')


### PR DESCRIPTION
Original implementation is far too risky. On my laptop `adb root` takes far more than 5 seconds (10+ seconds) and therefore it never succeeds.
This commit will solve the problem fundamentally.